### PR TITLE
Update dependencies to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.1</version>
+		<version>2.7.18</version>
 		<relativePath/>
 	</parent>
 	<groupId>pl.pieshakelbery</groupId>
@@ -38,8 +38,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
-			<version>2.5.4</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -53,23 +51,23 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.20</version>
+			<version>1.18.36</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct</artifactId>
-			<version>1.5.0.Beta1</version>
+			<version>1.6.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct-processor</artifactId>
-			<version>1.4.2.Final</version>
+			<version>1.6.3</version>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.24</version>
+			<version>8.0.33</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
- Spring Boot parent: 2.5.1 → 2.7.18 (last 2.x release compatible with Java 11)
- spring-boot-starter-data-jpa: remove pinned version, let parent BOM manage it
- Lombok: 1.18.20 → 1.18.36
- MapStruct + mapstruct-processor: align both to 1.6.3 (was mismatched 1.5.0.Beta1 / 1.4.2.Final)
- MySQL Connector Java: 8.0.24 → 8.0.33